### PR TITLE
Refactor pagination and media flows

### DIFF
--- a/src/composables/useInfiniteScroll.ts
+++ b/src/composables/useInfiniteScroll.ts
@@ -1,0 +1,80 @@
+import { onBeforeUnmount, ref, unref, watch, type MaybeRefOrGetter } from 'vue'
+
+export interface UseInfiniteScrollOptions extends IntersectionObserverInit {
+  isEnabled?: MaybeRefOrGetter<boolean>
+}
+
+export const useInfiniteScroll = (
+  onIntersect: () => void,
+  { isEnabled, ...observerOptions }: UseInfiniteScrollOptions = {},
+) => {
+  const target = ref<HTMLElement | null>(null)
+  let observer: IntersectionObserver | null = null
+
+  const cleanup = () => {
+    if (observer) {
+      if (target.value) {
+        observer.unobserve(target.value)
+      }
+      observer.disconnect()
+      observer = null
+    }
+  }
+
+  const ensureObserver = () => {
+    if (!observer) {
+      observer = new IntersectionObserver(entries => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            onIntersect()
+          }
+        })
+      }, observerOptions)
+    }
+  }
+
+  const tryObserve = () => {
+    const enabled = isEnabled === undefined || unref(isEnabled)
+    if (!enabled || !target.value) {
+      return
+    }
+
+    ensureObserver()
+    observer!.observe(target.value)
+  }
+
+  watch(
+    () => target.value,
+    (element, previousElement) => {
+      if (observer && previousElement) {
+        observer.unobserve(previousElement)
+      }
+
+      if (!element) {
+        return
+      }
+
+      tryObserve()
+    },
+    { flush: 'post' },
+  )
+
+  if (isEnabled !== undefined) {
+    watch(
+      () => unref(isEnabled),
+      enabled => {
+        if (!enabled) {
+          cleanup()
+        } else {
+          tryObserve()
+        }
+      },
+    )
+  }
+
+  onBeforeUnmount(() => {
+    cleanup()
+  })
+
+  return { target }
+}

--- a/src/composables/usePaginatedCollection.ts
+++ b/src/composables/usePaginatedCollection.ts
@@ -1,0 +1,101 @@
+import { computed, ref, unref, type MaybeRefOrGetter } from 'vue'
+
+export interface PaginatedFetchResult<TItem> {
+  items: TItem[]
+  total: number
+}
+
+export type PaginatedFetchFn<TItem> = (
+  page: number,
+  pageSize: number,
+) => Promise<PaginatedFetchResult<TItem>>
+
+export interface UsePaginatedCollectionOptions {
+  initialPage?: number
+  pageSize?: number
+  isEnabled?: MaybeRefOrGetter<boolean>
+}
+
+export const usePaginatedCollection = <TItem>(
+  fetchFn: PaginatedFetchFn<TItem>,
+  options: UsePaginatedCollectionOptions = {},
+) => {
+  const initialPage = options.initialPage ?? 1
+  const pageSize = options.pageSize ?? 10
+
+  const page = ref(initialPage)
+  const items = ref<TItem[]>([])
+  const total = ref(0)
+  const loading = ref(false)
+  const error = ref<unknown>(null)
+
+  const hasMore = computed(() => items.value.length < total.value)
+  const isInitialLoad = computed(
+    () => loading.value && items.value.length === 0 && !error.value,
+  )
+
+  const resetState = () => {
+    page.value = initialPage
+    items.value = []
+    total.value = 0
+    error.value = null
+  }
+
+  const load = async ({ reset = false }: { reset?: boolean } = {}) => {
+    if (loading.value) {
+      return
+    }
+
+    if (options.isEnabled !== undefined && !unref(options.isEnabled)) {
+      return
+    }
+
+    loading.value = true
+    error.value = null
+
+    if (reset) {
+      resetState()
+    }
+
+    try {
+      const { items: newItems, total: newTotal } = await fetchFn(
+        page.value,
+        pageSize,
+      )
+
+      total.value = newTotal
+
+      if (reset) {
+        items.value = [...newItems]
+      } else {
+        items.value = [...items.value, ...newItems]
+      }
+
+      if (items.value.length < total.value) {
+        page.value += 1
+      }
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  const refresh = async () => load({ reset: true })
+  const loadNext = async () => load()
+
+  return {
+    items,
+    total,
+    page,
+    pageSize,
+    loading,
+    error,
+    hasMore,
+    isInitialLoad,
+    refresh,
+    loadNext,
+    reset: resetState,
+  }
+}

--- a/src/lang/ru.ts
+++ b/src/lang/ru.ts
@@ -13,4 +13,5 @@ export default {
   show: 'Показать',
   search: 'Поиск',
   scan_desc: 'Bilediňizdäki qrcode-y okatmagyňyzy haýyş edýäris!',
+  empty_list: 'Список пуст',
 }

--- a/src/lang/tk.ts
+++ b/src/lang/tk.ts
@@ -13,4 +13,5 @@ export default {
   show: 'Görkez',
   search: 'Gözleg',
   scan_desc: 'Bilediňizdäki qrcode-y okatmagyňyzy haýyşt edýäris!',
+  empty_list: 'Sanaw boş',
 }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,6 +1,6 @@
-import type { AxiosResponse } from 'axios'
 import api from '@/plugins/api'
 import type { TPost, TSignInRes } from '@/types/auth'
+import type { AxiosResponse } from 'axios'
 
 export const signIn = async (body: TPost): Promise<AxiosResponse<TSignInRes>> =>
-  api.post('/auth/sign-in', body)
+  api.post<TSignInRes>('/auth/sign-in', body)

--- a/src/services/book.ts
+++ b/src/services/book.ts
@@ -1,9 +1,9 @@
+import api from '@/plugins/api'
 import type { TBookAll } from '@/types/book'
 import type { AxiosResponse } from 'axios'
-import api from '@/plugins/api'
 
 export const getBooks = async (
   page: number,
   count: number,
 ): Promise<AxiosResponse<TBookAll>> =>
-  api.get<TBookAll>(`/books?page=${page || 1}&count=${count || 1}`)
+  api.get<TBookAll>('/books', { params: { page, count } })

--- a/src/services/movies.ts
+++ b/src/services/movies.ts
@@ -17,14 +17,14 @@ export const getMovieById = async (
 export const getSubCatById = async (
   id: string,
 ): Promise<AxiosResponse<TMovieCategory>> =>
-  api.get<TMovieCategory>(`categories/sub/${id}`)
+  api.get<TMovieCategory>(`/categories/sub/${id}`)
 
 export const getMoviesByCatId = async (
   id: string,
   page: number,
   count: number,
 ): Promise<AxiosResponse<TMoviesBySubCatId>> =>
-  api.get<TMoviesBySubCatId>(`/movies/sub/${id}?page=${page}&count=${count}`)
+  api.get<TMoviesBySubCatId>(`/movies/sub/${id}`, { params: { page, count } })
 
 export const getHomePageMovies = async (): Promise<
   AxiosResponse<TMoviesHomePage>
@@ -37,4 +37,4 @@ export const getMovieCategories = async (): Promise<
 export const getSearchedMovies = async (
   searchValue: string,
 ): Promise<AxiosResponse<TMovie[]>> =>
-  api.get<TMovie[]>(`/movies/search/${searchValue}`)
+  api.get<TMovie[]>('/movies/search/' + searchValue)

--- a/src/services/music.ts
+++ b/src/services/music.ts
@@ -1,9 +1,9 @@
+import api from '@/plugins/api'
 import type { TMusicAll } from '@/types/music'
 import type { AxiosResponse } from 'axios'
-import api from '@/plugins/api'
 
 export const getMusicAll = async (
   page: number,
   count: number,
 ): Promise<AxiosResponse<TMusicAll>> =>
-  api.get<TMusicAll>(`/musics?page=${page || 1}&count=${count || 1}`)
+  api.get<TMusicAll>('/musics', { params: { page, count } })

--- a/src/store/movie.ts
+++ b/src/store/movie.ts
@@ -1,3 +1,4 @@
+import { usePaginatedCollection } from '@/composables/usePaginatedCollection'
 import {
   getHomePageMovies,
   getMoviesByCatId,
@@ -7,115 +8,149 @@ import {
 import type {
   TMovie,
   TMovieCategory,
-  TMoviesBySubCatId,
   TMoviesHomePage,
 } from '@/types/movie'
+import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
 
-export const useMovieStore = defineStore('counter', () => {
-  const moviesHomePage = ref<TMoviesHomePage>([])
-  const moviesWithScrollPagination = ref<TMoviesBySubCatId>()
-  const subCatIdData = ref<TMovieCategory>()
-  const moviesBySearch = ref<TMovie[]>([])
-  const movieNotFound = ref(false)
-  const page = ref(1)
-  const count = 10
-  const hasMore = ref(true)
-  const isMoviesFetched = ref(false)
-  // Loadings
-  const loading = ref(false)
-  const loadingForPaginated = ref(false)
-  const loadingSubCatId = ref(false)
-  const loadingSearched = ref(false)
-  const path = ref('sub')
-  async function fetchMovies() {
-    loading.value = true
-    if (!isMoviesFetched.value) {
-      try {
-        const res = await getHomePageMovies()
-        moviesHomePage.value = res.data
-      } catch {
-      } finally {
-        loading.value = false
-      }
+export const useMovieStore = defineStore('movie', () => {
+  const homeSections = ref<TMoviesHomePage>([])
+  const isHomeLoading = ref(false)
+  const hasLoadedHome = ref(false)
+
+  const fetchHome = async (force = false) => {
+    if (isHomeLoading.value || (!force && hasLoadedHome.value)) {
+      return
     }
-  }
 
-  async function fetchMoviesByIdWithPagination(id: string) {
-    loadingForPaginated.value = true
+    isHomeLoading.value = true
     try {
-      const res = await getMoviesByCatId(id, page.value, count)
-      if (page.value === 1) {
-        moviesWithScrollPagination.value = res.data
-        if (res.data.total > page.value * count) {
-          hasMore.value = true
-          page.value += 1
-        } else {
-          hasMore.value = false
-        }
-      } else {
-        moviesWithScrollPagination.value?.movies.push(...res.data.movies)
-        if (res.data.total > page.value * count) {
-          hasMore.value = true
-          page.value += 1
-        } else {
-          hasMore.value = false
-        }
-      }
-    } catch {
-      loadingForPaginated.value = false
-      hasMore.value = false
+      const { data } = await getHomePageMovies()
+      homeSections.value = data
+      hasLoadedHome.value = true
     } finally {
-      loadingForPaginated.value = false
+      isHomeLoading.value = false
     }
   }
 
-  async function getSubCatIdFn(id: string) {
-    loadingSubCatId.value = true
+  const selectedCategoryId = ref<string | null>(null)
+  const selectedCategory = ref<TMovieCategory | null>(null)
+  const isCategoryMetaLoading = ref(false)
+
+  const categoryPagination = usePaginatedCollection<TMovie>(
+    async (page, count) => {
+      if (!selectedCategoryId.value) {
+        return { items: [], total: 0 }
+      }
+      const { data } = await getMoviesByCatId(selectedCategoryId.value, page, count)
+      return {
+        items: data.movies,
+        total: data.total,
+      }
+    },
+    {
+      isEnabled: computed(() => Boolean(selectedCategoryId.value)),
+    },
+  )
+
+  const ensureCategoryMeta = async (id: string) => {
+    if (selectedCategory.value?.id === Number(id)) {
+      return
+    }
+
+    isCategoryMetaLoading.value = true
     try {
-      const res = await getSubCatById(id)
-      subCatIdData.value = res.data
-    } catch (err) {
-      console.log(err)
-      loadingSubCatId.value = false
+      const { data } = await getSubCatById(id)
+      selectedCategory.value = data
     } finally {
-      loadingSubCatId.value = false
+      isCategoryMetaLoading.value = false
     }
   }
 
-  async function getMoviesBySearch(searchVal: string) {
-    loadingSearched.value = true
-    try {
-      const res = await getSearchedMovies(searchVal)
-      if (!res.data.length) {
-        movieNotFound.value = true
-      }
-      moviesBySearch.value = res.data
-    } catch (err) {
-      loadingSearched.value = false
-      console.error(err)
-    } finally {
-      loadingSearched.value = false
+  const selectCategory = async (id: string) => {
+    if (!id) {
+      return
+    }
+
+    const isNewCategory = selectedCategoryId.value !== id
+    selectedCategoryId.value = id
+
+    await ensureCategoryMeta(id)
+
+    if (isNewCategory) {
+      await categoryPagination.refresh()
+    } else if (!categoryPagination.items.value.length) {
+      await categoryPagination.refresh()
     }
   }
+
+  const loadMoreCategoryMovies = async () => {
+    if (!categoryPagination.hasMore.value) {
+      return
+    }
+
+    await categoryPagination.loadNext()
+  }
+
+  const categoryMovies = computed(() => categoryPagination.items.value)
+  const isCategoryLoading = computed(() => categoryPagination.loading.value)
+  const isCategoryInitialLoading = computed(
+    () => categoryPagination.isInitialLoad.value,
+  )
+  const categoryHasMore = computed(() => categoryPagination.hasMore.value)
+
+  const searchResults = ref<TMovie[]>([])
+  const isSearching = ref(false)
+
+  const searchMovies = async (query: string) => {
+    const trimmedQuery = query.trim()
+    if (!trimmedQuery) {
+      searchResults.value = []
+      return
+    }
+
+    isSearching.value = true
+
+    try {
+      const { data } = await getSearchedMovies(trimmedQuery)
+      searchResults.value = data
+    } catch (error) {
+      console.error(error)
+      throw error
+    } finally {
+      isSearching.value = false
+    }
+  }
+
+  const clearSearch = () => {
+    searchResults.value = []
+  }
+
+  const isSearchEmpty = computed(
+    () => !searchResults.value.length && !isSearching.value,
+  )
+
+  const searchHasResults = computed(() => searchResults.value.length > 0)
 
   return {
-    loading,
-    moviesHomePage,
-    fetchMovies,
-    fetchMoviesByIdWithPagination,
-    moviesWithScrollPagination,
-    loadingSubCatId,
-    loadingForPaginated,
-    hasMore,
-    getSubCatIdFn,
-    subCatIdData,
-    page,
-    path,
-    getMoviesBySearch,
-    loadingSearched,
-    moviesBySearch,
-    movieNotFound,
+    homeSections,
+    isHomeLoading,
+    fetchHome,
+    selectedCategoryId,
+    selectedCategory,
+    isCategoryMetaLoading,
+    selectCategory,
+    loadMoreCategoryMovies,
+    categoryMovies,
+    isCategoryLoading,
+    isCategoryInitialLoading,
+    categoryHasMore,
+    searchResults,
+    isSearching,
+    searchMovies,
+    clearSearch,
+    isSearchEmpty,
+    searchHasResults,
   }
 })
+

--- a/src/views/book/BookView.vue
+++ b/src/views/book/BookView.vue
@@ -1,72 +1,64 @@
 <script setup lang="ts">
-import BookList from '@/components/book/BookList.vue'
-import { onMounted, onUnmounted, ref, watch } from 'vue'
-import { useBookStore } from '@/store/book'
 import AppLoading from '@/components/app/AppLoading.vue'
 import Wrapper from '@/components/app/WrapperComponent.vue'
+import BookList from '@/components/book/BookList.vue'
+import { useInfiniteScroll } from '@/composables/useInfiniteScroll'
+import { useBookStore } from '@/store/book'
+import { computed, onMounted } from 'vue'
+
 const store = useBookStore()
-const loadTrigger = ref(null)
-let observer: IntersectionObserver | null = null
-const createObserver = () => {
-  const options = {
-    root: null,
-    rootMargin: '0px',
-    threshold: 1.0, // Trigger when 100% of element is in view
-  }
 
-  const observer = new IntersectionObserver(entries => {
-    entries.forEach(entry => {
-      if (entry.isIntersecting && store.hasMore && !store.loading) {
-        store.getBooksFn()
-      }
-    })
-  }, options)
-
-  if (loadTrigger.value) {
-    observer.observe(loadTrigger.value)
-  }
-}
-
-watch(loadTrigger, newVal => {
-  if (newVal) createObserver()
-})
+const isScrollEnabled = computed(() => store.hasMore && !store.isLoading)
+const { target: loadMoreTrigger } = useInfiniteScroll(
+  () => {
+    if (!store.isLoading) {
+      void store.loadMore()
+    }
+  },
+  {
+    threshold: 0.25,
+    isEnabled: isScrollEnabled,
+  },
+)
 
 onMounted(() => {
-  createObserver()
-  store.page = 1
-  store.getBooksFn()
-})
-
-onUnmounted(() => {
-  if (observer) {
-    observer.disconnect()
-    observer = null
-  }
+  store.reset()
+  void store.loadInitial()
 })
 </script>
+
 <template>
   <Wrapper>
-    <AppLoading v-if="store.loading" />
+    <AppLoading v-if="store.isInitialLoading" />
     <div class="book_container">
-      <BookList v-if="store.books?.books.length" :books="store.books?.books" />
+      <BookList v-if="store.books.length" :books="store.books" />
+      <p v-else-if="!store.isLoading" class="empty_state">{{ $t('empty_list') }}</p>
       <div
-        ref="loadTrigger"
+        v-if="store.hasMore"
+        ref="loadMoreTrigger"
         class="load-trigger"
-        v-if="!store.loading && store.hasMore"
       >
-        Loading more books...
+        <img v-if="store.isLoading" src="/bars-scale-middle.svg" alt="Loading" />
       </div>
     </div>
   </Wrapper>
 </template>
+
 <style scoped>
 .book_container {
   position: relative;
 }
+
 .load-trigger {
   color: white;
   font-size: 1.2rem;
   text-align: center;
   padding: 1rem 0;
+}
+
+.empty_state {
+  color: var(--slate-300);
+  text-align: center;
+  padding: 2rem 0;
 }
 </style>

--- a/src/views/home/HomeView.vue
+++ b/src/views/home/HomeView.vue
@@ -1,27 +1,28 @@
 <script setup lang="ts">
-import { onMounted } from 'vue'
-import MovieList from '@/components/movie/MovieList.vue'
 import AppLoading from '@/components/app/AppLoading.vue'
+import MovieList from '@/components/movie/MovieList.vue'
 import { useMovieStore } from '@/store/movie'
+import { onMounted } from 'vue'
 
 const movieStore = useMovieStore()
 
 onMounted(() => {
-  movieStore.fetchMovies()
+  void movieStore.fetchHome()
 })
 </script>
 
 <template>
-  <AppLoading v-if="movieStore.loading" />
+  <AppLoading v-if="movieStore.isHomeLoading && !movieStore.homeSections.length" />
   <div v-else>
-    <div class="movie-list-home">
+    <div class="movie-list-home" v-if="movieStore.homeSections.length">
       <MovieList
-        v-bind:key="movies.id"
-        v-for="movies in movieStore.moviesHomePage"
-        :movies="movies"
+        v-for="section in movieStore.homeSections"
+        :key="section.id"
+        :movies="section"
         class="movie-list-home"
       />
     </div>
+    <p v-else class="empty_state">{{ $t('empty_list') }}</p>
   </div>
 </template>
 
@@ -31,5 +32,11 @@ onMounted(() => {
   max-width: var(--max-width);
   margin-inline: auto;
   padding-left: 4px;
+}
+
+.empty_state {
+  color: var(--slate-300);
+  text-align: center;
+  padding: 2rem 0;
 }
 </style>

--- a/src/views/movie/MoviesByCategory.vue
+++ b/src/views/movie/MoviesByCategory.vue
@@ -2,16 +2,21 @@
 import MoviesBySubCatId from '@/components/movie/MovieFetcher.vue'
 import { useMovieStore } from '@/store/movie'
 import type { TMovieCategory } from '@/types/movie'
-import { watch } from 'vue'
+import { computed, watch } from 'vue'
 import { useRoute } from 'vue-router'
+
 const route = useRoute()
 const store = useMovieStore()
 
+const selectedCategory = computed<TMovieCategory | undefined>(
+  () => store.selectedCategory ?? undefined,
+)
+
 watch(
   () => route.params.id,
-  newVal => {
-    if (newVal) {
-      store.getSubCatIdFn(route.params.id as string)
+  id => {
+    if (typeof id === 'string') {
+      void store.selectCategory(id)
     }
   },
   { immediate: true },
@@ -20,11 +25,8 @@ watch(
 
 <template>
   <MoviesBySubCatId
-    :movies="store.moviesWithScrollPagination?.movies ?? []"
-    :loading="store.loadingForPaginated"
-    :id="$route.params.id as string"
-    :data="store.subCatIdData as TMovieCategory"
-    :path="'search'"
     v-if="$route.params.id"
+    :id="$route.params.id as string"
+    :data="selectedCategory"
   />
 </template>

--- a/src/views/music/MusicItemView.vue
+++ b/src/views/music/MusicItemView.vue
@@ -82,31 +82,33 @@ const documentMouseMoveHandler = (e: MouseEvent) => {
 }
 
 const prevHandler = () => {
-  const findIndex =
-    store.music?.musics.findIndex(
-      item => item.id.toString() === route.params.id,
-    ) || 1
-  if (store.music?.musics.length) {
-    const prevIndex =
-      findIndex === 0 ? store.music?.musics.length - 1 : findIndex - 1
-    const prevMusic = store.music?.musics[prevIndex]
-    if (prevMusic.path) {
-      router.push({ name: 'music-id', params: { id: prevMusic.id } })
-    }
+  const tracks = store.tracks
+  if (!tracks.length) {
+    return
+  }
+
+  const currentIndex =
+    tracks.findIndex(item => item.id.toString() === route.params.id) || 0
+  const prevIndex = currentIndex === 0 ? tracks.length - 1 : currentIndex - 1
+  const prevTrack = tracks[prevIndex]
+
+  if (prevTrack?.path) {
+    router.push({ name: 'music-id', params: { id: prevTrack.id } })
   }
 }
 const nextHandler = () => {
-  const findIndex =
-    store.music?.musics.findIndex(
-      item => item.id.toString() === route.params.id,
-    ) || 0
-  if (store.music?.musics.length) {
-    const nextIndex =
-      findIndex === store.music?.musics.length - 1 ? 0 : findIndex + 1
-    const nextMusic = store.music?.musics[nextIndex]
-    if (nextMusic.path) {
-      router.push({ name: 'music-id', params: { id: nextMusic.id } })
-    }
+  const tracks = store.tracks
+  if (!tracks.length) {
+    return
+  }
+
+  const currentIndex =
+    tracks.findIndex(item => item.id.toString() === route.params.id) || 0
+  const nextIndex = currentIndex === tracks.length - 1 ? 0 : currentIndex + 1
+  const nextTrack = tracks[nextIndex]
+
+  if (nextTrack?.path) {
+    router.push({ name: 'music-id', params: { id: nextTrack.id } })
   }
 }
 
@@ -121,6 +123,10 @@ watch(
 )
 
 onMounted(() => {
+  if (!store.tracks.length) {
+    void store.loadInitial()
+  }
+
   if (audio_ref.value) {
     audio_ref.value.addEventListener('loadedmetadata', () => {
       totalAudioDuration.value = formatDuration(audio_ref.value?.duration)


### PR DESCRIPTION
## Summary
- add reusable pagination and infinite scroll composables and update book and music flows to use them
- refactor the movie store and related views for clearer category, search, and home page handling
- standardize media service helpers and empty state translations across the app

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913df847840832b9b0ecb44c3ed8cca)